### PR TITLE
Added link to NodeBB forum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ data
 .db
 *.env
 .vscode
+.idea

--- a/bin/setup
+++ b/bin/setup
@@ -12,6 +12,7 @@ const DEFAULT = `
 NODE_ENV=development
 BRFENERGI_LANG=sv
 PORT=3000
+FORUM_URL=http://localhost:3000
 
 # Services
 MAPBOX_ACCESS_TOKEN=<MAPBOX_TOKEN>

--- a/lib/components/page-head/index.js
+++ b/lib/components/page-head/index.js
@@ -147,8 +147,13 @@ module.exports = class PageHead extends Component {
             event.preventDefault()
           }
         }
-      }
-    }
+      },
+      forum: () => ({
+        href: process.env.FORUM_URL + '/authmetryifneeded',
+        title: __('Forum')
+      })
+
+  }
 
     return html`
       <div class="PageHead">
@@ -171,7 +176,7 @@ module.exports = class PageHead extends Component {
 
           <!-- Medium & large viewport: horizontal menu list -->
           <ul class="u-hidden u-md-block u-lg-block">
-            ${Object.values(pick(pages, 'faq', 'about')).map(page => {
+            ${Object.values(pick(pages, 'forum', 'faq', 'about')).map(page => {
               const props = page(this.state, this.emit)
               return html`
                 <li class="PageHead-item">


### PR DESCRIPTION
The link will try to perform authentication with metry automatically, if
the user isn't already logged in. That part is handled by the forum and
is already live.

Introduces new env variable: FORUM_URL
Needs to be set to the full address to the forum.

Note that this will probably not be enough for us to implement all the inter-operation features we want, but it's a tangible start to let users easily go to the forum from BRFApp.